### PR TITLE
chore: upgrade actions/cache from v2 to v4

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION
## Description
This PR upgrades the GitHub Actions cache from v2 to v4 in the following workflow files:
- `.github/workflows/pr.yaml`
- `.github/workflows/release.yaml`

The changes include:
- Upgrading `actions/cache@v2` to `actions/cache@v4`
- Maintaining the same caching configuration for Docker layers

This upgrade brings performance improvements and bug fixes from the latest version of the cache action.