### PR TITLE
patch: panic if unable to get ecr creds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/centml/platform/ecr-anywhere
 
 go 1.24.1
-toolchain go1.24.1
 
 require (
 	k8s.io/api v0.30.2

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -111,7 +111,8 @@ func (ecu *ecrCredentialInjector) Inject(secret *corev1.Secret) (patching.Operat
 	// Call the API to get ECR credentials
 	res, err := ecu.ecrClient.GetAuthorizationToken(context.Background(), &ecr.GetAuthorizationTokenInput{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get authorization token: %w", err)
+		ecu.ErrorLogger.Printf("Failed to get authorization token: %v", err)
+		panic(fmt.Errorf("failed to get authorization token: %w", err))
 	}
 	ecu.InfoLogger.Print("Received authorization data")
 

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -254,15 +254,20 @@ func TestInject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMock()
-
-			patches, err := injector.Inject(tt.secret)
 			if tt.expectedError != "" {
-				assert.EqualError(t, err, tt.expectedError)
+				if tt.name == "GetAuthorizationToken fails" {
+					assert.PanicsWithError(t, tt.expectedError, func() {
+						_, _ = injector.Inject(tt.secret)
+					})
+				} else {
+					_, err := injector.Inject(tt.secret)
+					assert.EqualError(t, err, tt.expectedError)
+				}
 			} else {
+				patches, err := injector.Inject(tt.secret)
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedPatches, patches)
 			}
-
 			mockECRClient.AssertExpectations(t)
 		})
 	}


### PR DESCRIPTION
Even though we could track/parse logs, a failing container seems more appropriate if it is unable to do its main task. Let me know if this is too drastic.. 